### PR TITLE
fix: mongodb storage adapter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
 
-import sys
 import os
-from setuptools import setup, find_packages
+import sys
 
+from setuptools import find_packages, setup
 
 if sys.version_info[0] != 3:
     sys.exit("Python3 is required in order to install Selinon")
@@ -45,7 +45,7 @@ setup(
     keywords='selinon celery yaml flow distributed-computing',
     extras_require={
         'celery': ['celery>=4,<6'],
-        'mongodb': ['pymongo'],
+        'mongodb': ['pymongo>=3.7'],
         'postgresql': ['SQLAlchemy', 'SQLAlchemy-Utils'],
         'redis': ['redis'],
         's3': ['boto3'],


### PR DESCRIPTION
fixes #168 

- Fixes pymongo version in mongodb extra as the changes made will break older versions
- Change `find` then `count` on the returned cursor to `count_documents` followed by a `find_one` if the checks on number of documents are successful
- Change deprecated `insert` call to new `insert_one`
