### PR TITLE
fix: typo count documents

### DIFF
--- a/selinon/storages/mongodb.py
+++ b/selinon/storages/mongodb.py
@@ -57,7 +57,7 @@ class MongoDB(DataStorage):
         assert self.is_connected()  # nosec
 
         filtering = {'_id': 0}
-        documents_count = self.collection.count_documents({'task_id': task_id}, filtering)
+        documents_count = self.collection.count_documents({'task_id': task_id})
 
         if documents_count > 1:
             raise ValueError("Multiple records with same task_id found")
@@ -97,7 +97,7 @@ class MongoDB(DataStorage):
         assert self.is_connected()  # nosec
 
         filtering = {'_id': 0}
-        documents_count = self.collection.count_documents({'task_id': task_id}, filtering)
+        documents_count = self.collection.count_documents({'task_id': task_id})
 
         if documents_count > 1:
             raise ValueError("Multiple records with same task_id found")


### PR DESCRIPTION
A bug was introduced in #169 (sorry about that) because of the behavior of filters which differs on `find` and `count_documents` methods.

Removing the filter fixes the issue
