### PR TITLE
feat: remove yanked codegen dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 click
-codegen
 graphviz
 jsonschema
 pyyaml

--- a/selinon/builtin_predicate.py
+++ b/selinon/builtin_predicate.py
@@ -167,7 +167,7 @@ class AndPredicate(NaryPredicate):
 
         :return: AST of describing all children predicates
         """
-        return ast.BoolOp(ast.And(), [ast.Expr(value=x.ast()) for x in self._children])
+        return ast.BoolOp(ast.And(), [x.ast() for x in self._children])
 
     @staticmethod
     def create(tree, nodes_from, flow, can_inspect_results):
@@ -201,7 +201,7 @@ class OrPredicate(NaryPredicate):
 
         :return: AST of describing all children predicates
         """
-        return ast.BoolOp(ast.Or(), [ast.Expr(value=x.ast()) for x in self._children])
+        return ast.BoolOp(ast.Or(), [x.ast() for x in self._children])
 
     @staticmethod
     def create(tree, nodes_from, flow, can_inspect_results):
@@ -235,7 +235,7 @@ class NotPredicate(UnaryPredicate):
 
         :return: AST of describing all children predicates
         """
-        return ast.UnaryOp(ast.Not(), ast.Expr(value=self._child.ast()))
+        return ast.UnaryOp(ast.Not(), self._child.ast())
 
     @staticmethod
     def create(tree, nodes_from, flow, can_inspect_results):

--- a/selinon/predicate.py
+++ b/selinon/predicate.py
@@ -7,12 +7,10 @@
 """Predicate interface - predicate for building conditions."""
 
 import abc
-
-import codegen
+import ast
 
 from .errors import ConfigurationError
-from .helpers import check_conf_keys
-from .helpers import dict2json
+from .helpers import check_conf_keys, dict2json
 
 
 class Predicate(metaclass=abc.ABCMeta):
@@ -98,8 +96,8 @@ class Predicate(metaclass=abc.ABCMeta):
         :type can_inspect_results: bool
         :rtype: Predicate
         """
+        from .builtin_predicate import AndPredicate, NotPredicate, OrPredicate
         from .leaf_predicate import LeafPredicate
-        from .builtin_predicate import OrPredicate, AndPredicate, NotPredicate
 
         if not tree:
             raise ConfigurationError("Bad condition '%s'" % tree)
@@ -162,7 +160,7 @@ class Predicate(metaclass=abc.ABCMeta):
 
         :return: predicate source code
         """
-        return codegen.to_source(self.ast())
+        return ast.unparse(self.ast())
 
     @abc.abstractmethod
     def check(self):

--- a/selinon/version.py
+++ b/selinon/version.py
@@ -1,1 +1,1 @@
-selinon_version = '1.3.0'
+selinon_version = '1.4.0'

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     url='https://github.com/selinon/selinon',
     license='BSD',
     keywords='selinon celery yaml flow distributed-computing',
+    python_requires=">=3.9",
     extras_require={
         'celery': ['celery>=4,<6'],
         'mongodb': ['pymongo>=3.7'],
@@ -54,9 +55,9 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Removes `codegen` package dependency as it has been yanked and can cause many build problems.
Replaces all `codegen` usages by python's builtin `ast` module

Since the replacement of `codegen.to_source` ([ast.unparse](https://docs.python.org/3/library/ast.html#ast.unparse)) has been introduced in python 3.9, this PR changes compatibility cap to 3.9